### PR TITLE
Edit zing backend connect

### DIFF
--- a/frontend/src/modules/Dashboard/Components/GroupCard.tsx
+++ b/frontend/src/modules/Dashboard/Components/GroupCard.tsx
@@ -66,7 +66,7 @@ export const GroupCard = ({
               fontSize: '1rem',
             }}
             onClick={() => {
-              history.push('/editZing', { params: 'z98mmggpO05931CviaUy' }) // TODO: @shichong replace with real docID
+              history.push(`/editZing/?id=${'z98mmggpO05931CviaUy'}`) // TODO: @shichong replace with real docID
             }}
             label={'Match'}
           />

--- a/frontend/src/modules/Dashboard/Components/GroupCard.tsx
+++ b/frontend/src/modules/Dashboard/Components/GroupCard.tsx
@@ -66,7 +66,7 @@ export const GroupCard = ({
               fontSize: '1rem',
             }}
             onClick={() => {
-              history.push('/editZing')
+              history.push('/editZing', { params: 'z98mmggpO05931CviaUy' }) // TODO: @shichong replace with real docID
             }}
             label={'Match'}
           />

--- a/frontend/src/modules/EditZing/Components/EditZing.tsx
+++ b/frontend/src/modules/EditZing/Components/EditZing.tsx
@@ -29,13 +29,13 @@ export const EditZing = () => {
   useEffect(() => {
     async function fetchGroups(zingId: string | null) {
       if (zingId) {
-        var zingData = await getZingGroups(zingId)
+        const zingData = await getZingGroups(zingId)
         setZingData(zingData)
 
         // parse out groups into Student[][]
         const zingGroup = zingData.group
         let realData: Student[][] = []
-        for (var id in zingGroup) {
+        for (let id in zingGroup) {
           const studentList = zingGroup[id].members
           realData.push(studentList)
         }

--- a/frontend/src/modules/EditZing/Components/EditZing.tsx
+++ b/frontend/src/modules/EditZing/Components/EditZing.tsx
@@ -16,9 +16,10 @@ import { FetchedZing } from 'EditZing/Types/Student'
 
 export const EditZing = () => {
   // get param that was set from history using location
-  const location = useLocation() as any
-  const params = location.state.params
-  const [zingId] = useState(params)
+  const { search } = useLocation()
+  const query = new URLSearchParams(search)
+  const id = query.get('id')
+  const [zingId] = useState(id)
 
   const fakeStudentGroupsFromJson: Student[][] = require('EditZing/fakeData.json')
   // full fetched zing object
@@ -26,8 +27,8 @@ export const EditZing = () => {
   // student groups parsed out from zingData into a Student[][]
   const [studentGroups, setStudentGroups] = useState(fakeStudentGroupsFromJson)
   useEffect(() => {
-    async function fetchGroups(zingId: string) {
-      if (zingId !== undefined) {
+    async function fetchGroups(zingId: string | null) {
+      if (zingId) {
         var zingData = await getZingGroups(zingId)
         setZingData(zingData)
 

--- a/frontend/src/modules/EditZing/Components/EditZing.tsx
+++ b/frontend/src/modules/EditZing/Components/EditZing.tsx
@@ -8,23 +8,31 @@ import {
   StyledText,
 } from 'EditZing/Styles/EditZing.style'
 import { GroupGrid } from 'EditZing/Components/GroupGrid'
-import { Student, SingleGroup } from 'EditZing/Types/Student'
+import { Student } from 'EditZing/Types/Student'
 import { DndProvider } from 'react-dnd'
 import { HTML5Backend } from 'react-dnd-html5-backend'
 import { getZingGroups, saveSwapStudent } from './Helpers'
+import { FetchedZing } from 'EditZing/Types/Student'
 
 export const EditZing = () => {
-  const fakeStudentGroupsFromJson: Student[][] = require('EditZing/fakeData.json')
+  // get param that was set from history using location
   const location = useLocation() as any
   const params = location.state.params
   const [zingId] = useState(params)
+
+  const fakeStudentGroupsFromJson: Student[][] = require('EditZing/fakeData.json')
+  // full fetched zing object
+  const [zingData, setZingData] = useState<FetchedZing | null>(null)
+  // student groups parsed out from zingData into a Student[][]
   const [studentGroups, setStudentGroups] = useState(fakeStudentGroupsFromJson)
   useEffect(() => {
     async function fetchGroups(zingId: string) {
-      console.log({ params })
       if (zingId !== undefined) {
-        var zing = await getZingGroups(zingId)
-        const zingGroup = zing.group
+        var zingData = await getZingGroups(zingId)
+        setZingData(zingData)
+
+        // parse out groups into Student[][]
+        const zingGroup = zingData.group
         let realData: Student[][] = []
         for (var id in zingGroup) {
           const studentList = zingGroup[id].members
@@ -96,13 +104,12 @@ export const EditZing = () => {
     setStudentGroups(groups)
   }
 
-  // TODO: COURSE SHOULDN'T BE HARDCODED
-  if (studentGroups !== fakeStudentGroupsFromJson) {
+  if (zingData) {
     return (
       <StyledContainer>
         <StyledLogoWrapper>
           <StyledLogo />
-          <StyledText>ZING 1100</StyledText>
+          <StyledText>{zingData.name}</StyledText>
         </StyledLogoWrapper>
         <DndProvider backend={HTML5Backend}>
           <Grid container spacing={1}>

--- a/frontend/src/modules/EditZing/Components/EditZing.tsx
+++ b/frontend/src/modules/EditZing/Components/EditZing.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
 import Grid from '@material-ui/core/Grid'
 import {
   StyledContainer,
@@ -14,18 +15,23 @@ import { getZingGroups, saveSwapStudent } from './Helpers'
 
 export const EditZing = () => {
   const fakeStudentGroupsFromJson: Student[][] = require('EditZing/fakeData.json')
-  const [zingId, setZingId] = useState('z98mmggpO05931CviaUy')
+  const location = useLocation() as any
+  const params = location.state.params
+  const [zingId] = useState(params)
   const [studentGroups, setStudentGroups] = useState(fakeStudentGroupsFromJson)
   useEffect(() => {
-    async function fetchGroups(docId: string) {
-      let zing = await getZingGroups(docId)
-      const zingGroup = zing.group
-      let realData: Student[][] = []
-      for (var id in zingGroup) {
-        const studentList = zingGroup[id].members
-        realData.push(studentList)
+    async function fetchGroups(zingId: string) {
+      console.log({ params })
+      if (zingId !== undefined) {
+        var zing = await getZingGroups(zingId)
+        const zingGroup = zing.group
+        let realData: Student[][] = []
+        for (var id in zingGroup) {
+          const studentList = zingGroup[id].members
+          realData.push(studentList)
+        }
+        setStudentGroups(realData)
       }
-      setStudentGroups(realData)
     }
     fetchGroups(zingId)
   }, [zingId])

--- a/frontend/src/modules/EditZing/Components/GroupGrid.tsx
+++ b/frontend/src/modules/EditZing/Components/GroupGrid.tsx
@@ -38,7 +38,7 @@ export const GroupGrid = ({
         <StyledGroupTextWrapper>
           <StyledGroupText>{'Group ' + String(groupIndex + 1)}</StyledGroupText>
           <StyledMetricBox>
-            <StyledMetricText>6.9</StyledMetricText>
+            <StyledMetricText>4.0</StyledMetricText>
           </StyledMetricBox>
         </StyledGroupTextWrapper>
         <Grid container spacing={2}>

--- a/frontend/src/modules/EditZing/Components/Helpers.tsx
+++ b/frontend/src/modules/EditZing/Components/Helpers.tsx
@@ -21,11 +21,14 @@ interface SwapPostData {
 }
 
 export async function saveSwapStudent(
-  zingId: string,
+  zingId: string | null,
   studentId: string,
   baseGroupId: number,
   destGroupId: number
 ) {
+  if (!zingId) {
+    throw new Error('zingId cannot be null or undefined')
+  }
   const data: SwapPostData = {
     studentId: studentId,
     baseGroupId: baseGroupId,

--- a/frontend/src/modules/EditZing/Components/Helpers.tsx
+++ b/frontend/src/modules/EditZing/Components/Helpers.tsx
@@ -1,0 +1,47 @@
+import { FetchedZing } from 'EditZing/Types/Student'
+const axios = require('axios')
+
+export async function getZingGroups(docId: String): Promise<FetchedZing> {
+  return fetch(
+    `https://us-central1-zing-backend.cloudfunctions.net/api/course/${docId}`
+  ).then(function (response: any) {
+    if (!response.ok) {
+      throw new Error(response.statusText)
+    }
+    const data = response.json()
+    console.log(data)
+    return data
+  })
+}
+
+interface SwapPostData {
+  studentId: string
+  baseGroupId: number
+  destGroupId: number
+}
+
+export async function saveSwapStudent(
+  zingId: string,
+  studentId: string,
+  baseGroupId: number,
+  destGroupId: number
+) {
+  const data: SwapPostData = {
+    studentId: studentId,
+    baseGroupId: baseGroupId,
+    destGroupId: destGroupId,
+  }
+  axios
+    .post(
+      `https://us-central1-zing-backend.cloudfunctions.net/api/course/${zingId}/group`,
+      data
+    )
+    .then(
+      (response: any) => {
+        console.log(response)
+      },
+      (error: any) => {
+        console.log(error)
+      }
+    )
+}

--- a/frontend/src/modules/EditZing/Components/Helpers.tsx
+++ b/frontend/src/modules/EditZing/Components/Helpers.tsx
@@ -9,7 +9,6 @@ export async function getZingGroups(docId: String): Promise<FetchedZing> {
       throw new Error(response.statusText)
     }
     const data = response.json()
-    console.log(data)
     return data
   })
 }

--- a/frontend/src/modules/EditZing/Components/StudentAnswer.tsx
+++ b/frontend/src/modules/EditZing/Components/StudentAnswer.tsx
@@ -1,0 +1,3 @@
+import React from 'react'
+import { makeStyles, createStyles, Theme } from '@material-ui/core/styles'
+import Paper from '@material-ui/core/Paper'

--- a/frontend/src/modules/EditZing/Components/StudentAnswer.tsx
+++ b/frontend/src/modules/EditZing/Components/StudentAnswer.tsx
@@ -1,3 +1,0 @@
-import React from 'react'
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles'
-import Paper from '@material-ui/core/Paper'

--- a/frontend/src/modules/EditZing/Components/StudentGrid.tsx
+++ b/frontend/src/modules/EditZing/Components/StudentGrid.tsx
@@ -94,7 +94,7 @@ export const StudentGrid = ({
               background: isOver ? colors.lightviolet : colors.verylightviolet,
             }}
           >
-            {genderSVG} {student.pronoun === 'a' ? 'Male' : 'Female'}
+            {genderSVG} {student.pronoun === 'She/Her' ? 'Female' : 'Male'}
           </div>
         </Paper>
       </div>

--- a/frontend/src/modules/EditZing/Types/Student.ts
+++ b/frontend/src/modules/EditZing/Types/Student.ts
@@ -1,3 +1,26 @@
+export type FetchedZing = {
+  name: string
+  creator: string
+  dueDateStr: string
+  minGroupSize: string
+  courseId: string
+  survey: any // bad but lazy
+  group: Group
+}
+
+export type Group = {
+  [key: string]: SingleGroup
+}
+
+export type SingleGroup = {
+  groupData: GroupData
+  members: Student[]
+}
+
+export type GroupData = {
+  failed: string[]
+}
+
 export type Student = {
   college: string
   courseId: string

--- a/frontend/src/modules/EditZing/Types/Student.ts
+++ b/frontend/src/modules/EditZing/Types/Student.ts
@@ -8,15 +8,19 @@ export type FetchedZing = {
   group: Group
 }
 
+// really should be groups (plural), but following woosang's structure
+// this is the KV pair GROUPS object where K are consecutive integers starting from 1 (i think)
 export type Group = {
   [key: string]: SingleGroup
 }
 
+// THIS is a really group (singular) object
 export type SingleGroup = {
   groupData: GroupData
   members: Student[]
 }
 
+// represents what constraints were failed
 export type GroupData = {
   failed: string[]
 }

--- a/frontend/src/modules/EditZing/Types/Student.ts
+++ b/frontend/src/modules/EditZing/Types/Student.ts
@@ -14,7 +14,7 @@ export type Group = {
   [key: string]: SingleGroup
 }
 
-// THIS is ACTUALLY group (singular) object
+// THIS is ACTUALLY a group (singular) object
 export type SingleGroup = {
   groupData: GroupData
   members: Student[]

--- a/frontend/src/modules/EditZing/Types/Student.ts
+++ b/frontend/src/modules/EditZing/Types/Student.ts
@@ -8,13 +8,13 @@ export type FetchedZing = {
   group: Group
 }
 
-// really should be groups (plural), but following woosang's structure
+// really should be groups (plural), but is formatted this way to follow woosang's response structure
 // this is the KV pair GROUPS object where K are consecutive integers starting from 1 (i think)
 export type Group = {
   [key: string]: SingleGroup
 }
 
-// THIS is a really group (singular) object
+// THIS is ACTUALLY group (singular) object
 export type SingleGroup = {
   groupData: GroupData
   members: Student[]


### PR DESCRIPTION
- Added useHistory params to pass to editZing from Dashboard's Group Card component. Allows us the ability to softcode the Zing ID. However, this isn't done yet, @shichong-97 has to look at the @shichong TODO comment and pass in the real variable that contains the Zing ID

- Takes Zing ID and fetches a get endpoint for real group data

- on StudentGrid drop, it calls a new post endpoint to update the location of the student based on startinggroupindex and destinationindex, allows drag-drop group data persistence and changes to be saved to backend