### PR TITLE
Replaced query params for Edit and Survey with React Hooks

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,7 +37,11 @@ const App = () => {
             <PublicRoute exact path={HOME_PATH} component={Home} />
             {/* Anyone should be able to access the survey, signed in or not */}
             <Route exact path={`${SURVEY_PATH}/:courseId`} component={Survey} />
-            <PrivateRoute exact path={EDIT_ZING_PATH} component={EditZing} />
+            <PrivateRoute
+              exact
+              path={`${EDIT_ZING_PATH}/:courseId`}
+              component={EditZing}
+            />
             <PrivateRoute exact path={DASHBOARD_PATH} component={Dashboard} />
           </Switch>
         </Router>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,7 +36,7 @@ const App = () => {
           <Switch>
             <PublicRoute exact path={HOME_PATH} component={Home} />
             {/* Anyone should be able to access the survey, signed in or not */}
-            <Route exact path={SURVEY_PATH} component={Survey} />
+            <Route exact path={`${SURVEY_PATH}/:courseId`} component={Survey} />
             <PrivateRoute exact path={EDIT_ZING_PATH} component={EditZing} />
             <PrivateRoute exact path={DASHBOARD_PATH} component={Dashboard} />
           </Switch>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,11 +37,15 @@ const App = () => {
             <PublicRoute exact path={HOME_PATH} component={Home} />
             {/* Anyone should be able to access the survey, signed in or not */}
             <Route exact path={`${SURVEY_PATH}/:courseId`} component={Survey} />
+            {/* To account for if there is no specified courseId */}
+            <Route exact path={SURVEY_PATH} component={Survey} />
             <PrivateRoute
               exact
               path={`${EDIT_ZING_PATH}/:courseId`}
               component={EditZing}
             />
+            {/* To account for if there is no specified courseId */}
+            <PrivateRoute exact path={EDIT_ZING_PATH} component={EditZing} />
             <PrivateRoute exact path={DASHBOARD_PATH} component={Dashboard} />
           </Switch>
         </Router>

--- a/frontend/src/modules/Core/Constants/Routes.ts
+++ b/frontend/src/modules/Core/Constants/Routes.ts
@@ -1,6 +1,6 @@
 export const HOME_PATH = '/'
 export const SURVEY_PATH = '/survey'
-export const EDIT_ZING_PATH = '/editZing'
+export const EDIT_ZING_PATH = '/edit'
 export const DASHBOARD_PATH = '/dashboard'
 
 export const BACKEND_ROOT =

--- a/frontend/src/modules/Dashboard/Components/GroupCard.tsx
+++ b/frontend/src/modules/Dashboard/Components/GroupCard.tsx
@@ -21,6 +21,7 @@ import {
   CSV_API,
   BACKEND_ROOT,
   CREATE_GROUPS_API,
+  DASHBOARD_PATH,
 } from '@core'
 import axios from 'axios'
 import { Alert, Button } from '@mui/material'
@@ -65,9 +66,9 @@ export const GroupCard = ({
           variant={new Date() > deadline ? 'outlined' : 'contained'}
           color={new Date() > deadline ? 'secondary' : 'primary'}
           onClick={() => {
-            const index = window.location.href.indexOf('/dashboard')
+            const index = window.location.href.indexOf(DASHBOARD_PATH)
             const baseUrl = window.location.href.slice(0, index)
-            navigator.clipboard.writeText(`${baseUrl}${SURVEY_PATH}?id=${id}`)
+            navigator.clipboard.writeText(`${baseUrl}${SURVEY_PATH}/${id}`)
             setOpen(true)
           }}
         >

--- a/frontend/src/modules/Dashboard/Components/GroupCard.tsx
+++ b/frontend/src/modules/Dashboard/Components/GroupCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useHistory } from 'react-router-dom'
+import { useHistory, useParams } from 'react-router-dom'
 import moment from 'moment'
 import Snackbar from '@mui/material/Snackbar'
 
@@ -87,7 +87,7 @@ export const GroupCard = ({
                     .catch((error: any) => {
                       console.log(error)
                     })
-                    .finally(() => history.push(`/editZing/?id=${id}`))
+                    .finally(() => history.push(`/edit/${id}`))
                 },
                 (error: any) => {
                   console.log(error)

--- a/frontend/src/modules/EditZing/Components/EditZing.tsx
+++ b/frontend/src/modules/EditZing/Components/EditZing.tsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect } from 'react'
+import ReactDOM from 'react-dom'
+import { useParams } from 'react-router-dom'
 import { useLocation } from 'react-router-dom'
 import Grid from '@mui/material/Grid'
 import {
@@ -24,6 +26,9 @@ export const EditZing = () => {
   const query = new URLSearchParams(search)
   const id = query.get('id')
   const [zingId] = useState(id)
+
+  // const { zingId } = useParams<{ id: string }>()
+  // const { courseId } = useParams<{ courseId: string }>()
 
   // buttons that are used for the "export" feature
   const exportButtons = [

--- a/frontend/src/modules/EditZing/Components/EditZing.tsx
+++ b/frontend/src/modules/EditZing/Components/EditZing.tsx
@@ -20,14 +20,36 @@ import { ExportButton } from 'EditZing/Components/ExportButton'
 import { Box } from '@mui/material'
 import { CSV_FILE, DOWNLOAD_ALL, HOME_PATH } from '@core'
 
+// import {
+//   CourseInfo,
+//   CourseInfoResponse,
+//   CourseStudentDataResponse,
+//   Group,
+// } from 'EditZing/Types/CourseInfo'
+// import axios, { AxiosResponse } from 'axios'
+
 export const EditZing = () => {
   // get param that was set from history using location
   const history = useHistory()
   const { courseId } = useParams<{ courseId: string }>()
 
   useEffect(() => {
-    if (!courseId) history.push(HOME_PATH)
+    if (!courseId) history.push(courseId)
   }, [courseId, history])
+
+  // const [courseInfo, setCourseInfo] = useState<CourseInfo>()
+
+  // useEffect(() => {
+  //   axios
+  //     .get(`${API_ROOT}${COURSE_API}/${courseId}`)
+  //     .then((res: AxiosResponse<CourseInfoResponse>) => {
+  //       setCourseInfo(res.data.data)
+  //     })
+  //     .catch((error) => {
+  //       console.error(error)
+  //       // setShowError(true)
+  //     })
+  // }, [courseId])
 
   // buttons that are used for the "export" feature
   const exportButtons = [

--- a/frontend/src/modules/EditZing/Components/EditZing.tsx
+++ b/frontend/src/modules/EditZing/Components/EditZing.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import ReactDOM from 'react-dom'
-import { useParams } from 'react-router-dom'
+import { useHistory, useParams } from 'react-router-dom'
 import { useLocation } from 'react-router-dom'
 import Grid from '@mui/material/Grid'
 import {
@@ -18,17 +18,16 @@ import { getZingGroups, saveSwapStudent } from './Helpers'
 import { FetchedZing } from 'EditZing/Types/Student'
 import { ExportButton } from 'EditZing/Components/ExportButton'
 import { Box } from '@mui/material'
-import { CSV_FILE, DOWNLOAD_ALL } from '@core'
+import { CSV_FILE, DOWNLOAD_ALL, HOME_PATH } from '@core'
 
 export const EditZing = () => {
   // get param that was set from history using location
-  const { search } = useLocation()
-  const query = new URLSearchParams(search)
-  const id = query.get('id')
-  const [zingId] = useState(id)
+  const history = useHistory()
+  const { courseId } = useParams<{ courseId: string }>()
 
-  // const { zingId } = useParams<{ id: string }>()
-  // const { courseId } = useParams<{ courseId: string }>()
+  useEffect(() => {
+    if (!courseId) history.push(HOME_PATH)
+  }, [courseId, history])
 
   // buttons that are used for the "export" feature
   const exportButtons = [
@@ -44,9 +43,9 @@ export const EditZing = () => {
   // student groups parsed out from zingData into a Student[][]
   const [studentGroups, setStudentGroups] = useState(fakeStudentGroupsFromJson)
   useEffect(() => {
-    async function fetchGroups(zingId: string | null) {
-      if (zingId) {
-        const zingData = await getZingGroups(zingId)
+    async function fetchGroups(courseId: string | null) {
+      if (courseId) {
+        const zingData = await getZingGroups(courseId)
         setZingData(zingData)
 
         // parse out groups into Student[][]
@@ -59,8 +58,8 @@ export const EditZing = () => {
         setStudentGroups(realData)
       }
     }
-    fetchGroups(zingId)
-  }, [zingId])
+    fetchGroups(courseId)
+  }, [courseId])
 
   /** Move a student from one grid to a destination grid based
    * on a starting and destination grid index */
@@ -98,7 +97,7 @@ export const EditZing = () => {
         })
       )
       saveSwapStudent(
-        zingId,
+        courseId,
         studentToMove.email,
         startingIndex + 1,
         destinationIndex + 1

--- a/frontend/src/modules/Survey/Components/Survey.tsx
+++ b/frontend/src/modules/Survey/Components/Survey.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useHistory, useLocation } from 'react-router'
+import { useHistory, useLocation, useParams } from 'react-router'
 import axios from 'axios'
 
 import { StyledContainer1, StyledContainer2 } from 'Survey/Styles/Survey.style'
@@ -12,15 +12,12 @@ import { useEffect } from 'react'
 import { API_ROOT, COURSE_API, HOME_PATH, SURVEY_API } from '@core/Constants'
 
 export const Survey = () => {
-  const { search } = useLocation()
   const history = useHistory()
-
-  const query = new URLSearchParams(search)
-  const surveyId = query.get('id')
+  const { courseId } = useParams<{ courseId: string }>()
 
   useEffect(() => {
-    if (!surveyId) history.push(HOME_PATH)
-  }, [surveyId, history])
+    if (!courseId) history.push(HOME_PATH)
+  }, [courseId, history])
 
   const [showError, setShowError] = useState(false)
   const [currStep, setCurrStep] = useState(0)
@@ -33,7 +30,7 @@ export const Survey = () => {
   // ^ here it is baby:
   useEffect(() => {
     const fetcher = async () => {
-      axios.get(`${API_ROOT}${COURSE_API}/${surveyId}${SURVEY_API}`).then(
+      axios.get(`${API_ROOT}${COURSE_API}/${courseId}${SURVEY_API}`).then(
         (response: any) => {
           setSurvey(response.data)
         },
@@ -43,7 +40,7 @@ export const Survey = () => {
       )
     }
     fetcher()
-  }, [surveyId])
+  }, [courseId])
 
   // Form answer props
   const [nameAnswer, setNameAnswer] = useState('')
@@ -67,7 +64,7 @@ export const Survey = () => {
       surveyResponse: mcData,
     }
     axios
-      .post(`${API_ROOT}${COURSE_API}/${surveyId}${SURVEY_API}`, surveyData)
+      .post(`${API_ROOT}${COURSE_API}/${courseId}${SURVEY_API}`, surveyData)
       .then(
         (response: any) => {
           console.log(response)


### PR DESCRIPTION
### Summary

Used React Hooks (specifically useParams) to simplify links in Grouper and make them more intuitive.

Example:
**Old:** `http://localhost:3000/survey?id=qrHfmYmZKIdFFvskpX0D`
**New:** `http://localhost:3000/survey/UmdnuvEBH6pC97LEj6Te`
_Note that `UmdnuvEBH6pC97LEj6Te` matches the id of the survey in Firebase._

Initially, survey and edit links were generated by using query parameters, which is not ideal and resulted in messy links. 

If no path is provided, redirects to `/dashboard` page.


### Test Plan <!-- Required -->

I tried testing various links to make sure the changes worked as expected. I also tried supplying made-up survey ids or no path to see if it redirects to the dashboard properly.

### Breaking Changes <!-- Optional -->

changed `/editZing` to `/edit` since the term "zing" is depreciated.