### PR TITLE
Add `channelId` field to actions to prevent breaking on merge

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -24,4 +24,5 @@ jobs:
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_ZING_BACKEND }}"
+          channelId: live
           projectId: zing-backend


### PR DESCRIPTION
# Summary <!-- Required -->

https://github.com/FirebaseExtended/action-hosting-deploy/issues/98

Solved by adding channelId directly. See https://github.com/cornell-dti/zing-lsc/blob/main/.github/workflows/firebase-hosting-merge.yml in zing-lsc.